### PR TITLE
Fix invalid format error

### DIFF
--- a/01_static_website/README.md
+++ b/01_static_website/README.md
@@ -34,6 +34,7 @@ docker run --rm --publish 8080:80 --volume $(pwd):/usr/share/nginx/html:ro nginx
 ```
 
 NOTE: If you are using Windows you can run it in Powershell by replacing `$(pwd)` with `${pwd}`.
+:information_source: If you get the following error `docker: invalid reference format.`, try wrapping the volume fields with double quotes, i.e. `--volume "$(pwd):/usr/share/nginx/html:ro"`.
 
 You should then be able to view the website by opening http://localhost:8080 in a browser.
 

--- a/01_static_website/README.md
+++ b/01_static_website/README.md
@@ -33,7 +33,7 @@ We can do this by adding the `--volume` or `-v` flag to the command.
 docker run --rm --publish 8080:80 --volume $(pwd):/usr/share/nginx/html:ro nginx
 ```
 
-NOTE: If you are using Windows you can run it in Powershell by replacing `$(pwd)` with `${pwd}`.
+:information_source: If you are using Windows you can run it in Powershell by replacing `$(pwd)` with `${pwd}`.
 :information_source: If you get the following error `docker: invalid reference format.`, try wrapping the volume fields with double quotes, i.e. `--volume "$(pwd):/usr/share/nginx/html:ro"`.
 
 You should then be able to view the website by opening http://localhost:8080 in a browser.

--- a/01_static_website/README.md
+++ b/01_static_website/README.md
@@ -34,6 +34,7 @@ docker run --rm --publish 8080:80 --volume $(pwd):/usr/share/nginx/html:ro nginx
 ```
 
 :information_source: If you are using Windows you can run it in Powershell by replacing `$(pwd)` with `${pwd}`.
+
 :information_source: If you get the following error `docker: invalid reference format.`, try wrapping the volume fields with double quotes, i.e. `--volume "$(pwd):/usr/share/nginx/html:ro"`.
 
 You should then be able to view the website by opening http://localhost:8080 in a browser.

--- a/04_jupyter_notebook/README.md
+++ b/04_jupyter_notebook/README.md
@@ -49,6 +49,7 @@ docker run --rm --publish 8888:8888 --volume $(pwd)/notebooks:/notebooks jupyter
 ```
 
 :information_source: If you are using Windows you need to replace `$(pwd)` with `${pwd}`.
+:information_source: If you get the following error `docker: invalid reference format.`, try wrapping the volume fields with double quotes, i.e. `--volume "$(pwd):/usr/share/nginx/html:ro"`.
 
 ## Do some data science!
 We should now be able to access our notebook.

--- a/04_jupyter_notebook/README.md
+++ b/04_jupyter_notebook/README.md
@@ -49,6 +49,7 @@ docker run --rm --publish 8888:8888 --volume $(pwd)/notebooks:/notebooks jupyter
 ```
 
 :information_source: If you are using Windows you need to replace `$(pwd)` with `${pwd}`.
+
 :information_source: If you get the following error `docker: invalid reference format.`, try wrapping the volume fields with double quotes, i.e. `--volume "$(pwd):/usr/share/nginx/html:ro"`.
 
 ## Do some data science!


### PR DESCRIPTION
When running `docker run --rm --publish 8080:80 --volume $(pwd):/usr/share/nginx/html:ro nginx
`, I get the following error message `docker: invalid reference format.` due to a space in the path of the current working directory. This can be fixed by wrapping the the volume argument with double quotes.

Might be better to change the actual instruction, but I'm not sure if double quotes have the same meaning in PowerShell.